### PR TITLE
chore: pin pnpm via packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          package_json_file: gallery/package.json
 
       - name: 🛠️ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -30,7 +30,7 @@ jobs:
       - name: 📦 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          package_json_file: gallery/package.json
           run_install: false
 
       - name: 📥 Install dependencies

--- a/gallery/app/__tests__/parse.test.ts
+++ b/gallery/app/__tests__/parse.test.ts
@@ -20,7 +20,7 @@ describe("YAML Validation", () => {
 	it.each(entries)(
 		"should validate %s and warn about unknown keys",
 		async (path, content) => {
-			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
 			const config = YAML.parse(content as string);
 			expect(() => validateWidgetConfig(config, path)).not.toThrow();


### PR DESCRIPTION
Adds `"packageManager": "pnpm@9.14.2"` to `package.json` and drops the redundant `version:` arg from `pnpm/action-setup` in CI.

The action now reads the version from `packageManager`, giving a single source of truth shared between local dev and CI. Matches the convention used in `marimo` and `marimo-lsp`.