### PR TITLE
chore(ci): add --ignore-scripts to pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           run_install: false
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: 🔍 Run linter
         run: pnpm lint


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare in CI. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change.