### PR TITLE
chore: bump node-version to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 🛠️ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: 'gallery/pnpm-lock.yaml'
 


### PR DESCRIPTION
Aligns CI Node version with other marimo-team repos (Node 24).